### PR TITLE
Handle zero duration formatting for projects

### DIFF
--- a/src/components/ProjectsTable/components/ProjectTableRow/ProjectTableRow.tsx
+++ b/src/components/ProjectsTable/components/ProjectTableRow/ProjectTableRow.tsx
@@ -35,6 +35,9 @@ export const ProjectTableRow: React.FC<ProjectTableRowProps> = ({
         project.max_bonus_interest ?? undefined
     );
 
+    const parsedDaysToGetMoney = Number(project.days_to_get_money);
+    const daysToGetMoney = Number.isNaN(parsedDaysToGetMoney) ? undefined : parsedDaysToGetMoney;
+
     return (
         <tr className={styles.row}>
             {/* Project Image */}
@@ -87,7 +90,7 @@ export const ProjectTableRow: React.FC<ProjectTableRowProps> = ({
             {/* Time */}
             <td className={styles.cell}>
                 {project.status === 'open_for_investments'
-                    ? formatDuration(Number(project.days_to_get_money))  // Fix: Convert string to number
+                    ? formatDuration(daysToGetMoney)
                     : project.funded_duration}
             </td>
 

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -25,8 +25,12 @@ export const formatInterestRate = (
         : `${basicInterest.toFixed(1)}%`;
 };
 
-export const formatDuration = (days?: number): string => {
-    return days ? `${days} d.` : '—';
+export const formatDuration = (days?: number | null): string => {
+    if (days !== undefined && days !== null && Number.isFinite(days)) {
+        return `${days} d.`;
+    }
+
+    return '—';
 };
 
 export const formatMonths = (months: number): string => {


### PR DESCRIPTION
## Summary
- ensure `formatDuration` treats zero as a valid value while guarding against non-finite inputs
- normalize project row `days_to_get_money` parsing before calling the formatter

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8b1fa19e88333a51e4066f5217812