### PR TITLE
Refactor ProjectFilters accordion to use configuration map

### DIFF
--- a/src/components/ProjectFilters/ProjectFilters.tsx
+++ b/src/components/ProjectFilters/ProjectFilters.tsx
@@ -28,6 +28,12 @@ interface ProjectFiltersProps {
     onClearFilters: () => void;
 }
 
+interface FilterSection {
+    index: number;
+    title: string;
+    render: () => React.ReactNode;
+}
+
 const ProjectFilters: React.FC<ProjectFiltersProps> = ({
                                                            tempFilters,
                                                            accordionActiveItems,
@@ -54,6 +60,113 @@ const ProjectFilters: React.FC<ProjectFiltersProps> = ({
         toggleButtonRef.current?.focus();
     };
 
+    const filterSections: FilterSection[] = [
+        {
+            index: 0,
+            title: 'Šalis',
+            render: () => (
+                <div className={styles.checkboxGrid}>
+                    {COUNTRY_OPTIONS.map(country => (
+                        <Checkbox
+                            key={country.code}
+                            label={country.label}
+                            checked={tempFilters.countries.includes(country.code)}
+                            onChange={(checked) => onCountryChange(country.code, checked)}
+                            icon={<CountryFlag countryCode={country.code} size="small" />}
+                        />
+                    ))}
+                </div>
+            )
+        },
+        {
+            index: 1,
+            title: 'Pradinis reitingas',
+            render: () => (
+                <div className={styles.checkboxGrid}>
+                    {RATING_OPTIONS.map(rating => (
+                        <Checkbox
+                            key={rating}
+                            label={rating}
+                            checked={tempFilters.ratings.includes(rating)}
+                            onChange={(checked) => onRatingChange(rating, checked)}
+                        />
+                    ))}
+                </div>
+            )
+        },
+        {
+            index: 2,
+            title: 'Paskirtis / Tipas',
+            render: () => (
+                <div className={styles.filterContent}>
+                    <Select
+                        options={PURPOSE_OPTIONS}
+                        value={tempFilters.purpose}
+                        onChange={(value) => onTempFilterChange('purpose', value)}
+                        placeholder="Visos paskirtys"
+                        fullWidth
+                    />
+                </div>
+            )
+        },
+        {
+            index: 3,
+            title: 'Kredito trukmė (mėn.)',
+            render: () => (
+                <div className={styles.rangeInputs}>
+                    <InputNumber
+                        placeholder="Min"
+                        value={tempFilters.creditDurationMin}
+                        onChange={(value) =>
+                            onTempFilterChange('creditDurationMin', value === '' ? '' : String(value))
+                        }
+                        min={0}
+                        fullWidth
+                    />
+                    <InputNumber
+                        placeholder="Max"
+                        value={tempFilters.creditDurationMax}
+                        onChange={(value) =>
+                            onTempFilterChange('creditDurationMax', value === '' ? '' : String(value))
+                        }
+                        min={0}
+                        fullWidth
+                    />
+                </div>
+            )
+        },
+        {
+            index: 4,
+            title: 'Kampanijos ID',
+            render: () => (
+                <div className={styles.filterContent}>
+                    <InputText
+                        placeholder="Įveskite kampanijos ID"
+                        value={tempFilters.campaignId}
+                        onChange={(value) => onTempFilterChange('campaignId', value)}
+                        icon={<Hash size={16} />}
+                        fullWidth
+                    />
+                </div>
+            )
+        },
+        {
+            index: 5,
+            title: 'Privatus ID',
+            render: () => (
+                <div className={styles.filterContent}>
+                    <InputText
+                        placeholder="Įveskite privatų ID"
+                        value={tempFilters.privateId}
+                        onChange={(value) => onTempFilterChange('privateId', value)}
+                        icon={<Search size={16} />}
+                        fullWidth
+                    />
+                </div>
+            )
+        }
+    ];
+
     return (
         <FilterBar
             isOpen={isFilterOpen}
@@ -66,121 +179,16 @@ const ProjectFilters: React.FC<ProjectFiltersProps> = ({
                     activeItems={accordionActiveItems}
                     onItemsChange={onAccordionChange}
                 >
-                    <AccordionItem index={0}>
-                        <AccordionHeader index={0}>
-                            Šalis
-                        </AccordionHeader>
-                        <AccordionContent index={0}>
-                            <div className={styles.checkboxGrid}>
-                                {COUNTRY_OPTIONS.map(country => (
-                                    <Checkbox
-                                        key={country.code}
-                                        label={country.label}
-                                        checked={tempFilters.countries.includes(country.code)}
-                                        onChange={(checked) => onCountryChange(country.code, checked)}
-                                        icon={<CountryFlag countryCode={country.code} size="small" />}
-                                    />
-                                ))}
-                            </div>
-                        </AccordionContent>
-                    </AccordionItem>
-
-                    <AccordionItem index={1}>
-                        <AccordionHeader index={1}>
-                            Pradinis reitingas
-                        </AccordionHeader>
-                        <AccordionContent index={1}>
-                            <div className={styles.checkboxGrid}>
-                                {RATING_OPTIONS.map(rating => (
-                                    <Checkbox
-                                        key={rating}
-                                        label={rating}
-                                        checked={tempFilters.ratings.includes(rating)}
-                                        onChange={(checked) => onRatingChange(rating, checked)}
-                                    />
-                                ))}
-                            </div>
-                        </AccordionContent>
-                    </AccordionItem>
-
-                    <AccordionItem index={2}>
-                        <AccordionHeader index={2}>
-                            Paskirtis / Tipas
-                        </AccordionHeader>
-                        <AccordionContent index={2}>
-                            <div className={styles.filterContent}>
-                                <Select
-                                    options={PURPOSE_OPTIONS}
-                                    value={tempFilters.purpose}
-                                    onChange={(value) => onTempFilterChange('purpose', value)}
-                                    placeholder="Visos paskirtys"
-                                    fullWidth
-                                />
-                            </div>
-                        </AccordionContent>
-                    </AccordionItem>
-
-                    <AccordionItem index={3}>
-                        <AccordionHeader index={3}>
-                            Kredito trukmė (mėn.)
-                        </AccordionHeader>
-                        <AccordionContent index={3}>
-                            <div className={styles.rangeInputs}>
-                                <InputNumber
-                                    placeholder="Min"
-                                    value={tempFilters.creditDurationMin}
-                                    onChange={(value) =>
-                                        onTempFilterChange('creditDurationMin', value === '' ? '' : String(value))
-                                    }
-                                    min={0}
-                                    fullWidth
-                                />
-                                <InputNumber
-                                    placeholder="Max"
-                                    value={tempFilters.creditDurationMax}
-                                    onChange={(value) =>
-                                        onTempFilterChange('creditDurationMax', value === '' ? '' : String(value))
-                                    }
-                                    min={0}
-                                    fullWidth
-                                />
-                            </div>
-                        </AccordionContent>
-                    </AccordionItem>
-
-                    <AccordionItem index={4}>
-                        <AccordionHeader index={4}>
-                            Kampanijos ID
-                        </AccordionHeader>
-                        <AccordionContent index={4}>
-                            <div className={styles.filterContent}>
-                                <InputText
-                                    placeholder="Įveskite kampanijos ID"
-                                    value={tempFilters.campaignId}
-                                    onChange={(value) => onTempFilterChange('campaignId', value)}
-                                    icon={<Hash size={16} />}
-                                    fullWidth
-                                />
-                            </div>
-                        </AccordionContent>
-                    </AccordionItem>
-
-                    <AccordionItem index={5}>
-                        <AccordionHeader index={5}>
-                            Privatus ID
-                        </AccordionHeader>
-                        <AccordionContent index={5}>
-                            <div className={styles.filterContent}>
-                                <InputText
-                                    placeholder="Įveskite privatų ID"
-                                    value={tempFilters.privateId}
-                                    onChange={(value) => onTempFilterChange('privateId', value)}
-                                    icon={<Search size={16} />}
-                                    fullWidth
-                                />
-                            </div>
-                        </AccordionContent>
-                    </AccordionItem>
+                    {filterSections.map(({ index, title, render }) => (
+                        <AccordionItem key={index} index={index}>
+                            <AccordionHeader index={index}>
+                                {title}
+                            </AccordionHeader>
+                            <AccordionContent index={index}>
+                                {render()}
+                            </AccordionContent>
+                        </AccordionItem>
+                    ))}
                 </Accordion>
 
                 <div className={styles.filterActions}>


### PR DESCRIPTION
## Summary
- replace the hard-coded accordion items in `ProjectFilters` with a data-driven configuration
- move section-specific rendering logic into configuration entries to keep the component concise