### PR TITLE
Fix action button class assignment for open projects

### DIFF
--- a/src/components/ProjectsTable/components/ProjectTableCell/ActionButtonCell.module.scss
+++ b/src/components/ProjectsTable/components/ProjectTableCell/ActionButtonCell.module.scss
@@ -18,6 +18,11 @@
     }
   }
 
+  &.defaultButton {
+    // Default state relies on base button styles. This selector provides a stable
+    // hook without altering the appearance.
+  }
+
   &.comingSoonButton {
     button {
       background: #ffa726 !important;

--- a/src/components/ProjectsTable/components/ProjectTableCell/ActionButtonCell.tsx
+++ b/src/components/ProjectsTable/components/ProjectTableCell/ActionButtonCell.tsx
@@ -16,6 +16,8 @@ export const ActionButtonCell: React.FC<ActionButtonCellProps> = ({
                                                                       onAction
                                                                   }) => {
     const config = PROJECT_STATUS_CONFIG[status] || PROJECT_STATUS_CONFIG.open_for_investments;
+    const statusClass = config.className ? styles[config.className] : '';
+    const wrapperClassName = [styles.buttonWrapper, statusClass].filter(Boolean).join(' ');
 
     const handleClick = () => {
         if (!config.disabled && onAction) {
@@ -24,7 +26,7 @@ export const ActionButtonCell: React.FC<ActionButtonCellProps> = ({
     };
 
     return (
-        <div className={`${styles.buttonWrapper} ${styles[config.className]}`}>
+        <div className={wrapperClassName}>
             <Button
                 size="small"
                 disabled={config.disabled}

--- a/src/config/projectStatus.ts
+++ b/src/config/projectStatus.ts
@@ -39,6 +39,6 @@ export const PROJECT_STATUS_CONFIG: Record<ProjectStatusEnum, StatusConfig> = {
     open_for_investments: {
         text: 'Investuokite',
         disabled: false,
-        className: ''
+        className: 'defaultButton'
     }
 } as const;


### PR DESCRIPTION
## Summary
- guard the action button wrapper class against missing status modifiers
- give the open for investments status an explicit style hook in config and styles
