### PR TITLE
Add button type prop with safe default

### DIFF
--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -11,6 +11,7 @@ interface ButtonProps {
     color?: string;
     icon?: React.ReactNode;
     iconPosition?: 'left' | 'right';
+    type?: 'button' | 'submit' | 'reset';
 }
 
 export default function Button({
@@ -22,7 +23,8 @@ export default function Button({
                                    className = '',
                                    color,
                                    icon,
-                                   iconPosition = 'left'
+                                   iconPosition = 'left',
+                                   type = 'button'
                                }: ButtonProps) {
     const buttonStyle = color && variant === 'ghost' ? {
         '--custom-color': color,
@@ -35,6 +37,7 @@ export default function Button({
             onClick={onClick}
             disabled={disabled}
             style={buttonStyle}
+            type={type}
         >
             {icon && iconPosition === 'left' && (
                 <span className={styles.icon}>{icon}</span>


### PR DESCRIPTION
## Summary
- allow the shared Button component to accept an optional HTML button type
- default the type to "button" so the component no longer submits forms implicitly
- forward the type attribute to the rendered <button> element for explicit submits

## Testing
- npm run lint (warning: existing missing dependency in useProjects)


------
https://chatgpt.com/codex/tasks/task_e_68d8b4bb64bc8333b4fddea483e97f8e