### PR TITLE
Fix ProjectTableCell barrel path

### DIFF
--- a/src/components/ProjectsTable/components/ProjectTableCell/index.ts
+++ b/src/components/ProjectsTable/components/ProjectTableCell/index.ts
@@ -1,0 +1,2 @@
+export { ActionButtonCell } from './ActionButtonCell';
+export { LTVCell } from './LTVCell';


### PR DESCRIPTION
## Summary
- rename the ProjectTableCell barrel file to remove the leading space in its path
- re-export ActionButtonCell and LTVCell from the barrel so other modules can import from the directory root
